### PR TITLE
Adds MQTT TLS support

### DIFF
--- a/src/HomeAutio.Mqtt.Core/BrokerSettings.cs
+++ b/src/HomeAutio.Mqtt.Core/BrokerSettings.cs
@@ -29,5 +29,10 @@
         /// Broker reconnect delay in seconds, default 5.
         /// </summary>
         public int BrokerReconnectDelay { get; set; } = 5;
+
+        /// <summary>
+        /// Whether to use TLS for the connection or not. Defaults to false.
+        /// </summary>
+        public bool UseTls {get; set; } = false;
     }
 }

--- a/src/HomeAutio.Mqtt.Core/BrokerSettings.cs
+++ b/src/HomeAutio.Mqtt.Core/BrokerSettings.cs
@@ -33,6 +33,6 @@
         /// <summary>
         /// Whether to use TLS for the connection or not. Defaults to false.
         /// </summary>
-        public bool UseTls {get; set; } = false;
+        public bool BrokerUseTls { get; set; } = false;
     }
 }

--- a/src/HomeAutio.Mqtt.Core/ServiceBase.cs
+++ b/src/HomeAutio.Mqtt.Core/ServiceBase.cs
@@ -146,7 +146,7 @@ namespace HomeAutio.Mqtt.Core
                 .WithWillMessage(willMessage);
 
             // MQTT TLS support
-            if (_brokerSettings.UseTls)
+            if (_brokerSettings.BrokerUseTls)
                 optionsBuilder.WithTls();
 
             // MQTT credentials

--- a/src/HomeAutio.Mqtt.Core/ServiceBase.cs
+++ b/src/HomeAutio.Mqtt.Core/ServiceBase.cs
@@ -145,6 +145,10 @@ namespace HomeAutio.Mqtt.Core
                 .WithCleanSession()
                 .WithWillMessage(willMessage);
 
+            // MQTT TLS support
+            if (_brokerSettings.UseTls)
+                optionsBuilder.WithTls();
+
             // MQTT credentials
             if (!string.IsNullOrEmpty(_brokerSettings.BrokerUsername) && !string.IsNullOrEmpty(_brokerSettings.BrokerPassword))
                 optionsBuilder.WithCredentials(_brokerSettings.BrokerUsername, _brokerSettings.BrokerPassword);


### PR DESCRIPTION
I'm wanting to use your awesome google-home mqtt bridge project, and I'd like to use MQTT TLS too.

This PR adds optional TLS support to the MQTT connection. Would appreciate it if you could review and pull this in, then update your HomeAutio.Mqtt.GoogleHome repo to utilise this new version of HomeAutio.Mqtt.Core.

Thanks!